### PR TITLE
Fix 5e tools import and multi spell trait support

### DIFF
--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -232,7 +232,7 @@ export const Statblock5e: StatblockItem[] = [
         type: "table",
         id: nanoid(),
         properties: ["stats"],
-        headers: ["Str", "Dex", "Con", "Wis", "Int", "Cha"],
+        headers: ["Str", "Dex", "Con", "Int", "Wis", "Cha"],
         calculate: true,
         hasRule: true,
         conditioned: true
@@ -508,7 +508,7 @@ export const Statblock5e: StatblockItem[] = [
         value: 30,
         xp: 155000
     }
-};                        
+};
 if ("cr" in monster && monster.cr in CR) {
     return \`\${CR[
         monster.cr
@@ -711,7 +711,7 @@ return "";`
         value: 30,
         xp: 155000
     }
-};           
+};
 if ("cr" in monster && monster.cr in CR) {
     return \`+\${Math.max(
             Math.floor(2 + ((CR[monster.cr]?.value ?? 0) - 1) / 4),

--- a/src/importers/5eToolsImport.ts
+++ b/src/importers/5eToolsImport.ts
@@ -55,7 +55,7 @@ export async function build5eMonsterFromFile(file: File): Promise<Monster[]> {
                             alignment: getAlignmentString(monster),
                             hp: monster.hp?.average ?? "",
                             hit_dice: monster.hp?.formula ?? "",
-                            ac: (monster.ac ?? [])[0]?.ac ?? "",
+                            ac: getAc(monster.ac),
                             speed: getSpeedString(monster),
                             stats: [
                                 monster.str,
@@ -186,6 +186,17 @@ function parseImmune(immune: any[]): string {
     }
     return ret.join(", ");
 }
+
+function getAc(acField: Array<number | { ac: number }> = []) {
+  const [item] = acField;
+
+  if (typeof item === 'number') {
+    return item;
+  }
+
+  return item.ac;
+}
+
 const spellMap: { [key: string]: string } = {
     "0": "Cantrips (at will)",
     "1": "1st level",

--- a/src/importers/5eToolsImport.ts
+++ b/src/importers/5eToolsImport.ts
@@ -11,16 +11,23 @@ const abilityMap: { [key: string]: string } = {
 
 function parseString(str: string) {
     return str
-        .replace(/\{\@condition (.+?)}/g, "$1")
-        .replace(/\{\@spell ([\s\S]+?)\}/g, `$1`)
-        .replace(/\{\@recharge (.+?)\}/g, `Recharge $1`)
-        .replace(/\{\@h\}/g, ``)
-        .replace(/\{\@damage (.+?)\}/g, `$1`)
-        .replace(/\{\@atk ms\}/g, `Melee Spell Attack`)
-        .replace(/\{\@atk mw\}/g, `Melee Weapon Attack`)
-        .replace(/\{\@atk rw\}/g, `Ranged Weapon Attack`)
-        .replace(/\{\@hit (\d+?)\}/g, `+$1`)
-        .replace(/\{\@dc (\d+?)\}/g, `$1`);
+        .replace(/{@condition (.+?)}/g, "$1")
+        .replace(/{@item (.+?)}/g, "$1")
+        .replace(/{@spell ([\s\S]+?)}/g, `$1`)
+        .replace(/{@recharge (.+?)}/g, `(Recharge $1-6)`)
+        .replace(/{@recharge}/g, `(Recharge 6)`)
+        .replace(/{@h}/g, ``)
+        .replace(/{@damage (.+?)}/g, `$1`)
+        .replace(/{@atk ms}/g, `Melee Spell Attack`)
+        .replace(/{@atk rs}/g, `Ranged Spell Attack`)
+        .replace(/{@atk mw}/g, `Melee Weapon Attack`)
+        .replace(/{@atk rw}/g, `Ranged Weapon Attack`)
+        .replace(/{@atk mw,rw}/g, `Melee / Ranged Weapon Attack`)
+        .replace(/{@creature (.+?)}/g, `$1`)
+        .replace(/{@skill (.+?)}/g, `$1`)
+        .replace(/{@dice (.+?)}/g, `$1`)
+        .replace(/{@hit (\d+?)}/g, `+$1`)
+        .replace(/{@dc (\d+?)}/g, `$1`);
 }
 
 export async function build5eMonsterFromFile(file: File): Promise<Monster[]> {

--- a/src/view/ui/Traits.svelte
+++ b/src/view/ui/Traits.svelte
@@ -7,7 +7,9 @@
 </script>
 
 <div class="property">
-    <div class="property-name">{name}</div>
+    {#if name}
+        <div class="property-name">{name}</div>
+    {/if}
     <div class="property-text">
         <TextContentHolder {render} property={desc} />
     </div>


### PR DESCRIPTION
Hi,
i've tried to import characters from 5e and found some small problems
- some template code was left untouched
- AC for some creatures wasn't extracted
- for some creatures that has both 'spellcasting' and 'innate spellcasting' only first block rendered in statblock

this pr is trying to fix them

for the last clause probably should be better solution, at the moment i render trait without name, for the second spellcasting block, something like this:

<img width="451" alt="Screenshot 2022-01-22 at 18 36 18" src="https://user-images.githubusercontent.com/1402135/150647944-cef22dd4-7669-4d14-831e-e58c2ca2b397.png">


