### PR TITLE
Added Support for "Bonus Actions" trait

### DIFF
--- a/@types/index.ts
+++ b/@types/index.ts
@@ -51,6 +51,7 @@ export interface Monster {
     traits?: Trait[];
     spells?: Spell[];
     actions?: Trait[];
+    bonus_actions?: Trait[];
     legendary_actions?: Trait[];
     reactions?: Trait[];
     monster?: string;
@@ -74,10 +75,11 @@ export interface Monster {
 export interface StatblockParameters
     extends Omit<
         Monster,
-        "traits" | "actions" | "legendary_actions" | "reactions"
+        "traits" | "actions" | "bonus_actions" | "legendary_actions" | "reactions"
     > {
     traits?: { desc: string; name: string }[] | [string, string][];
     actions?: Trait[] | [string, string][];
+    bonus_actions?: Trait[] | [string, string][];
     legendary_actions?: Trait[] | [string, string][];
     reactions?: Trait[] | [string, string][];
 }

--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ actions:
 legendary_actions:
   - [<legendary_actions-name>, <legendary_actions-description>]
   - ...
+bonus_actions:
+  - [<trait-name>, <trait-description>]
+  - ... 
 reactions:
   - [<reaction-name>, <reaction-description>]
   - ...

--- a/src/layouts/basic5e.ts
+++ b/src/layouts/basic5e.ts
@@ -596,6 +596,15 @@ return "";`
     {
         type: "traits",
         id: nanoid(),
+        properties: ["bonus_actions"],
+        heading: "Bonus Actions",
+        conditioned: true,
+
+        dice: true
+    },
+    {
+        type: "traits",
+        id: nanoid(),
         properties: ["legendary_actions"],
         heading: "Legendary Actions",
         conditioned: true,

--- a/src/main.ts
+++ b/src/main.ts
@@ -428,6 +428,10 @@ export default class StatBlockPlugin extends Plugin {
                     monster.actions ?? [],
                     params.actions ?? []
                 );
+                let bonus_actions = transformTraits(
+                    monster.bonus_actions ?? [],
+                    params.bonus_actions ?? []
+                );
                 let legendary_actions = transformTraits(
                     monster.legendary_actions ?? [],
                     params.legendary_actions ?? []
@@ -440,6 +444,7 @@ export default class StatBlockPlugin extends Plugin {
                 Object.assign(params, {
                     traits,
                     actions,
+                    bonus_actions,
                     reactions,
                     legendary_actions
                 });

--- a/src/watcher/watcher.worker.ts
+++ b/src/watcher/watcher.worker.ts
@@ -89,6 +89,9 @@ class Parser {
         if (monster.actions) {
             monster.actions = transformTraits([], monster.actions);
         }
+        if (monster.bonus_actions) {
+            monster.bonus_actions = transformTraits([], monster.bonus_actions);
+        }
         if (monster.reactions) {
             monster.reactions = transformTraits([], monster.reactions);
         }


### PR DESCRIPTION
closes #14 

Added bonus_actions to the StatblockParameters type.

Added bonus_actions to the postprocessor trait cleanup block.

Added bonus_actions to the basic5e StatblockItem array.

Added bonus_actions to the parseFileForCreatures function in watcher.worker.

Added bonus_actions to the README example.