### PR TITLE
Fix markdown holder styling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules
 
 # build
 main.js
+styles.css
 *.js.map
 .DS_Store
 *build.js

--- a/src/view/ui/MarkdownHolder.svelte
+++ b/src/view/ui/MarkdownHolder.svelte
@@ -14,4 +14,13 @@
     };
 </script>
 
-<div use:markdown />
+<div class="statblock-markdown" use:markdown />
+
+<style>
+    .statblock-markdown {
+        display: inline;
+    }
+    .statblock-markdown :global(p) {
+        display: inline;
+    }
+</style>


### PR DESCRIPTION
Force display inline when rendering a block as markdown

See issue #60