### PR TITLE
Bonus action importing

### DIFF
--- a/src/importers/5eToolsImport.ts
+++ b/src/importers/5eToolsImport.ts
@@ -110,6 +110,8 @@ export async function build5eMonsterFromFile(file: File): Promise<Monster[]> {
                                 monster.trait?.flatMap(normalizeEntries) ?? [],
                             actions:
                                 monster.action?.flatMap(normalizeEntries) ?? [],
+                            bonus_actions:
+                                monster.bonus?.flatMap(normalizeEntries) ?? [],
                             reactions:
                                 monster.reaction?.flatMap(normalizeEntries) ??
                                 [],

--- a/src/importers/ImprovedInitiativeImport.ts
+++ b/src/importers/ImprovedInitiativeImport.ts
@@ -128,7 +128,7 @@ export async function buildMonsterFromImprovedInitiativeFile(
                                     }
                                 ) ?? [],
                             bonus_actions:
-                                monster.BonusActions.map(
+                                monster.BonusActions?.map(
                                 (trait: {
                                     Name: string;
                                     Content: string;

--- a/src/importers/ImprovedInitiativeImport.ts
+++ b/src/importers/ImprovedInitiativeImport.ts
@@ -127,6 +127,7 @@ export async function buildMonsterFromImprovedInitiativeFile(
                                         };
                                     }
                                 ) ?? [],
+                            bonus_actions:
                                 monster.BonusActions.map(
                                 (trait: {
                                     Name: string;

--- a/src/importers/ImprovedInitiativeImport.ts
+++ b/src/importers/ImprovedInitiativeImport.ts
@@ -127,6 +127,17 @@ export async function buildMonsterFromImprovedInitiativeFile(
                                         };
                                     }
                                 ) ?? [],
+                                monster.BonusActions.map(
+                                (trait: {
+                                    Name: string;
+                                    Content: string;
+                                }) => {
+                                    return {
+                                        name: trait.Name,
+                                        desc: trait.Content
+                                    };
+                                }
+                            ) ?? [],
                             reactions:
                                 monster.Reactions?.map(
                                     (trait: {


### PR DESCRIPTION
fixed #70 

EDIT: added bonus action importing for improved initiative tracker too. Looks like all the rest of the sites/databases importing is implemented for either doesn't support bonus actions as their own section (they use traits for that) or don't have any monsters to import that have bonus actions