### PR TITLE
Custom separator for subheading properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ src/importers/*.json
 *.dev.*
 
 .env
+data.json

--- a/src/layouts/types.ts
+++ b/src/layouts/types.ts
@@ -80,6 +80,7 @@ type SpellsProps = {
 };
 type SubHeadingProps = {
     type: "subheading";
+    separator: string;
 };
 type TableProps = {
     type: "table";

--- a/src/settings/ui/block.ts
+++ b/src/settings/ui/block.ts
@@ -61,20 +61,6 @@ export class BlockModal extends Modal {
                             this.buildProperties(el);
                         })
                     );
-                new Setting(container)
-                    .setName("Separator")
-                    .setDesc(
-                        "Text used to separate properties of the subheading."
-                    )
-                    .addText((t) => {
-                        if (!this.block.separator) {
-                            this.block.separator = " ";
-                        }
-                        t.setValue(this.block.separator).onChange((v) => {
-                            this.block.separator = v;
-                        });
-                    });
-                    
 
                 const additional = container.createDiv("additional");
                 for (const property of this.block.properties) {
@@ -244,6 +230,23 @@ export class BlockModal extends Modal {
             }
         }
     }
+    buildSeparator(el: HTMLDivElement) {
+        el.empty();
+        
+        if (this.block.type == "subheading") {
+            new Setting(el)
+                .setName("Separator")
+                .setDesc("Text separating properties")
+                .addText((t) => {
+                    if (!this.block.separator) {
+                        this.block.separator = " ";
+                    }
+                    t.setValue(this.block.separator).onChange((v) => {
+                        this.block.separator = v;
+                    });
+                });
+        }
+    }
     buildConditions(el: HTMLDivElement) {
         el.empty();
         new Setting(el)
@@ -350,6 +353,7 @@ export class BlockModal extends Modal {
             });
 
         this.buildProperties(this.contentEl.createDiv());
+        this.buildSeparator(this.contentEl.createDiv());
         this.buildConditions(this.contentEl.createDiv());
         this.buildDice(this.contentEl.createDiv());
 

--- a/src/settings/ui/block.ts
+++ b/src/settings/ui/block.ts
@@ -7,7 +7,8 @@ import {
     type TraitsItem,
     type TableItem,
     MarkdownTypes,
-    type TextItem
+    type TextItem,
+    type SubHeadingItem
 } from "src/layouts/types";
 import type StatBlockPlugin from "src/main";
 import TableHeaders from "./TableHeaders.svelte";
@@ -60,6 +61,21 @@ export class BlockModal extends Modal {
                             this.buildProperties(el);
                         })
                     );
+                new Setting(container)
+                    .setName("Separator")
+                    .setDesc(
+                        "Text used to separate properties of the subheading."
+                    )
+                    .addText((t) => {
+                        if (!this.block.separator) {
+                            this.block.separator = " ";
+                        }
+                        t.setValue(this.block.separator).onChange((v) => {
+                            this.block.separator = v;
+                        });
+                    });
+                    
+
                 const additional = container.createDiv("additional");
                 for (const property of this.block.properties) {
                     new Setting(additional)

--- a/src/view/ui/Subheading.svelte
+++ b/src/view/ui/Subheading.svelte
@@ -16,7 +16,7 @@
 
 {#if subheading.length}
     <div class="subheading">
-        {subheading.join(item.separator)}
+        {subheading.join(item.separator ?? " ")}
     </div>
 {/if}
 

--- a/src/view/ui/Subheading.svelte
+++ b/src/view/ui/Subheading.svelte
@@ -16,7 +16,7 @@
 
 {#if subheading.length}
     <div class="subheading">
-        {subheading.join(" ")}
+        {subheading.join(item.separator)}
     </div>
 {/if}
 


### PR DESCRIPTION
By default, the subheading properties are separated with just a space. I just added a text field in the subheading block to enter a different separator. By default it's locked to this:
<img width="406" alt="Space" src="https://user-images.githubusercontent.com/77210114/184463796-1ce2f179-4ace-46af-990a-8e18a3ae1b4f.png">
with no ability to change it (short of changing the code). With this, you can set it to " / ", ", " " | ", etc. Anything should work. Example:
<img width="411" alt="Separated" src="https://user-images.githubusercontent.com/77210114/184463858-4b8fd1b4-5d38-4f56-9ebd-082462113154.png">

Added data.json to .gitignore because it kept showing up and wouldn't go away, lmk if this needs to be removed.
