### PR TITLE
Custom logic for stat mod calculations + Disabling SRD monsters + False statements in Property Line + footerEntries from 5etools

### DIFF
--- a/@types/index.ts
+++ b/@types/index.ts
@@ -58,6 +58,7 @@ export interface Monster {
     monster?: string;
     creature?: string;
     source?: string;
+    spellsNotes?: string;
 
     /** Fate Core */
     description?: string;

--- a/src/data/srd-bestiary.ts
+++ b/src/data/srd-bestiary.ts
@@ -16819,7 +16819,11 @@ export const BESTIARY: Monster[] = [
     BESTIARY.map((monster) => [monster.name, monster])
 ); */
 
-export const BESTIARY_BY_NAME: Map<string, Monster> = new Map(
+export function getBestiaryByName (disableSRD: boolean) {
+    return !disableSRD ? BESTIARY_BY_NAME : new Map();
+}
+
+const BESTIARY_BY_NAME: Map<string, Monster> = new Map(
     BESTIARY.map((monster) => {
         /*         const statblock: StatblockMonster = Object.assign({}, monster, {
             traits: new Map(),

--- a/src/importers/5eToolsImport.ts
+++ b/src/importers/5eToolsImport.ts
@@ -1,5 +1,4 @@
 import type { Monster } from "@types";
-import { element } from "svelte/internal";
 
 const abilityMap: { [key: string]: string } = {
     str: "strength",

--- a/src/importers/5eToolsImport.ts
+++ b/src/importers/5eToolsImport.ts
@@ -1,4 +1,5 @@
 import type { Monster } from "@types";
+import { element } from "svelte/internal";
 
 const abilityMap: { [key: string]: string } = {
     str: "strength",
@@ -118,7 +119,8 @@ export async function build5eMonsterFromFile(file: File): Promise<Monster[]> {
                             legendary_actions:
                                 monster.legendary?.flatMap(normalizeEntries) ??
                                 [],
-                            spells: getSpells(monster)
+                            spells: getSpells(monster),
+                            spellsNotes: getSpellNotes(monster).join(" ")
                         };
                         imported.push(importedMonster);
                     } catch (e) {
@@ -136,6 +138,18 @@ export async function build5eMonsterFromFile(file: File): Promise<Monster[]> {
 
         reader.readAsText(file);
     });
+}
+
+function getSpellNotes (monster: any) {
+    let spellNotes: string[] = []
+
+    for (const element in monster.spellcasting) {
+        for (const key in monster.spellcasting[element].footerEntries) {
+            spellNotes.push(monster.spellcasting[element].footerEntries[key]);
+        }
+    }
+
+    return spellNotes;
 }
 
 function parseImmune(immune: any[]): string {

--- a/src/layouts/basic5e.ts
+++ b/src/layouts/basic5e.ts
@@ -594,6 +594,14 @@ return "";`
         dice: true
     },
     {
+        type: "text",
+        id: nanoid(),
+        properties: ["spellsNotes"],
+        conditioned: true,
+
+        text: null
+    },
+    {
         type: "traits",
         id: nanoid(),
         properties: ["actions"],

--- a/src/layouts/types.ts
+++ b/src/layouts/types.ts
@@ -86,6 +86,7 @@ type TableProps = {
     type: "table";
     headers: string[];
     calculate: boolean;
+    modifier?: string;
 };
 type TraitsProps = {
     type: "traits";

--- a/src/main.ts
+++ b/src/main.ts
@@ -271,8 +271,8 @@ export default class StatBlockPlugin extends Plugin {
         this.data.delete(monster);
         this.bestiary.delete(monster);
 
-        if (BESTIARY_BY_NAME.has(monster)) {
-            this.bestiary.set(monster, BESTIARY_BY_NAME.get(monster));
+        if (getBestiaryByName(this.settings.disableSRD).has(monster)) {
+            this.bestiary.set(monster, getBestiaryByName(this.settings.disableSRD).get(monster));
         }
 
         if (save) await this.saveSettings();

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,7 @@ import {
 } from "obsidian";
 import domtoimage from "dom-to-image";
 
-import { BESTIARY_BY_NAME } from "./data/srd-bestiary";
+import { getBestiaryByName } from "./data/srd-bestiary";
 import StatBlockRenderer from "./view/statblock";
 import { transformTraits } from "./util/util";
 import {
@@ -58,6 +58,7 @@ export interface StatblockData {
     };
     path: string;
     autoParse: boolean;
+    disableSRD: boolean;
 }
 
 const DEFAULT_DATA: StatblockData = {
@@ -74,7 +75,8 @@ const DEFAULT_DATA: StatblockData = {
         patch: null
     },
     path: "/",
-    autoParse: false
+    autoParse: false,
+    disableSRD: false
 };
 
 export default class StatBlockPlugin extends Plugin {
@@ -155,7 +157,7 @@ export default class StatBlockPlugin extends Plugin {
         addIcon(SAVE_SYMBOL, SAVE_ICON);
         addIcon(EXPORT_SYMBOL, EXPORT_ICON);
 
-        this.bestiary = new Map([...BESTIARY_BY_NAME, ...this.data]);
+        this.bestiary = new Map([...getBestiaryByName(this.settings.disableSRD), ...this.data]);
 
         Object.defineProperty(window, "bestiary", {
             value: this.bestiary,
@@ -202,6 +204,7 @@ export default class StatBlockPlugin extends Plugin {
     }
     async saveSettings() {
         this.settings.monsters = this._transformData(this.data);
+        this.bestiary = new Map([...getBestiaryByName(this.settings.disableSRD), ...this.data]);
 
         await this.saveData(this.settings);
     }

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -147,6 +147,21 @@ export default class StatblockSettingTab extends PluginSettingTab {
                         await this.plugin.saveSettings();
                     })
             );
+        new Setting(container)
+            .setName("Disable 5e SRD")
+            .setDesc(
+                createFragment((e) => {
+                    e.createSpan({
+                        text: "Disable the Dungeons & Dragons 5th Edition System Reference Document monsters."
+                    });     
+                })
+            )
+            .addToggle((t) =>
+                t.setValue(this.plugin.settings.disableSRD).onChange(async (v) => {
+                    this.plugin.settings.disableSRD = v;
+                    await this.plugin.saveSettings();
+                })
+            );
     }
     generateParseSettings(containerEl: HTMLDivElement) {
         containerEl.empty();

--- a/src/settings/ui/block.ts
+++ b/src/settings/ui/block.ts
@@ -228,6 +228,27 @@ export class BlockModal extends Modal {
                         (this.block as PropertyItem).callback = v;
                     });
             }
+            if (this.block.type == "table") {
+                new Setting(el)
+                    .setHeading()
+                    .setName("Ability Modifier Calculation")
+                    .setDesc(
+                        createFragment((e) => {
+                            e.createSpan({
+                                text: "Allows a custom modifier for the stat."
+                            });
+                            e.createEl("br");
+                            e.createSpan({ text: "Variable " });
+                            e.createEl("code", { text: "stat" });
+                            e.createSpan({ text: "is accessible, use this to calculate the modifier." });
+                        })
+                    );
+                new TextAreaComponent(el)
+                    .setValue(this.block.modifier)
+                    .onChange((v) => {                        
+                        (this.block as TableItem).modifier = v;
+                    });
+            }
         }
     }
     buildSeparator(el: HTMLDivElement) {

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -29,7 +29,7 @@ export const stringify = (
     if (depth == 5) {
         return "";
     }
-    if (!property || property == null) return ``;
+    if (property == null) return ``;
     if (typeof property == "string") return property;
     if (typeof property == "number") return `${property}`;
     if (Array.isArray(property)) {

--- a/src/view/ui/PropertyLine.svelte
+++ b/src/view/ui/PropertyLine.svelte
@@ -10,7 +10,8 @@
     export let monster: Monster;
     export let item: PropertyItem;
 
-    let property = stringify(monster[item.properties[0]]);
+    let property = monster[item.properties[0]];
+    property = property.toString();
     let display = item.display ?? item.properties[0];
 
     if (item.callback) {
@@ -34,7 +35,7 @@
     }
 </script>
 
-{#if !item.conditioned || (item.conditioned && `${property}`.length)}
+{#if !item.conditioned || (item.conditioned && `${property}` !== null)}
     <div class="line">
         <span class="property-name">{display}</span>
         <TextContentHolder render={item.markdown} {property} />

--- a/src/view/ui/PropertyLine.svelte
+++ b/src/view/ui/PropertyLine.svelte
@@ -34,7 +34,7 @@
     }
 </script>
 
-{#if !item.conditioned || (item.conditioned && `${property}` !== null)}
+{#if !item.conditioned || (item.conditioned && `${property}` != null)}
     <div class="line">
         <span class="property-name">{display}</span>
         <TextContentHolder render={item.markdown} {property} />

--- a/src/view/ui/PropertyLine.svelte
+++ b/src/view/ui/PropertyLine.svelte
@@ -10,7 +10,7 @@
     export let monster: Monster;
     export let item: PropertyItem;
 
-    let property = monster[item.properties[0]];
+    let property = monster[item.properties[0]] ?? "";
     property = property.toString();
     let display = item.display ?? item.properties[0];
 

--- a/src/view/ui/PropertyLine.svelte
+++ b/src/view/ui/PropertyLine.svelte
@@ -34,7 +34,7 @@
     }
 </script>
 
-{#if !item.conditioned || (item.conditioned && `${property}` != null)}
+{#if !item.conditioned || (item.conditioned && `${property}`.length)}
     <div class="line">
         <span class="property-name">{display}</span>
         <TextContentHolder render={item.markdown} {property} />

--- a/src/view/ui/PropertyLine.svelte
+++ b/src/view/ui/PropertyLine.svelte
@@ -10,8 +10,7 @@
     export let monster: Monster;
     export let item: PropertyItem;
 
-    let property = monster[item.properties[0]] ?? "";
-    property = property.toString();
+    let property = stringify(monster[item.properties[0]]);
     let display = item.display ?? item.properties[0];
 
     if (item.callback) {

--- a/src/view/ui/Table.svelte
+++ b/src/view/ui/Table.svelte
@@ -5,8 +5,12 @@
     export let monster: Monster;
     export let item: TableItem;
 
-    function getMod(stat: number) {
-        let mod = Math.floor(((stat ?? 10) - 10) / 2);
+    const customMod = new Function('stat', `return ${item.modifier}`);
+
+    function getMod(stat: number) {        
+        let mod = item.modifier == null || !item.modifier.length || item.modifier == ""? 
+            Math.floor(((stat ?? 10) - 10) / 2) : 
+            customMod(stat);
         return `${mod >= 0 ? "+" : "-"}${Math.abs(mod)}`;
     }
 


### PR DESCRIPTION
Added #48 and #57
Fixed #67 and #78 

This is only a half fix for #78. This only adds the footerEntries of _some_ of the 5eTools monsters. The ones with footerEntries in variants were not added (though I believe variants are already not supported anyways).