### PR TITLE
Adds support for markdown-style links in statblock codeblocks

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -557,6 +557,12 @@ export default class StatBlockPlugin extends Plugin {
                     .replace(/\[\[([^"]+?)\]\]/g, (match, p1) => {
                         return `<STATBLOCK-LINK>${p1}</STATBLOCK-LINK>`;
                     })
+                    .replace(/\[([^"]*?)\]\(([^"]+?)\)/g, (s, alias: string, path: string) => {
+                        if (alias.length) {
+                            return `<STATBLOCK-LINK>${path}|${alias}</STATBLOCK-LINK>`;
+                        }
+                        return `<STATBLOCK-LINK>${path}</STATBLOCK-LINK>`;
+                    })
             );
 
             let statblock = new StatBlockRenderer(


### PR DESCRIPTION
Markdown-style links in statblock codeblocks would not get picked up during rendering:

![image](https://user-images.githubusercontent.com/5295276/196949602-164a8b46-ba58-4c9e-80e2-9f4c736a3e22.png)

The regex to search for links has been updated to include markdown-style links:

![image](https://user-images.githubusercontent.com/5295276/196949342-8fa780e6-12f2-4aee-b5a5-af44f8544b60.png)

Note: I did not update the changelog 