### PR TITLE
Add support for additional variables with 5etools importer

### DIFF
--- a/src/importers/5eToolsImport.ts
+++ b/src/importers/5eToolsImport.ts
@@ -39,12 +39,27 @@ function parseString(str: string) {
         .replace(/{@atk mw}/g, `Melee Weapon Attack`)
         .replace(/{@atk rw}/g, `Ranged Weapon Attack`)
         .replace(/{@atk mw,rw}/g, `Melee / Ranged Weapon Attack`)
+        .replace(/{@atkr m}/g, `Melee Attack Roll:`)
+        .replace(/{@atkr r}/g, `Ranged Attack Roll:`)
+        .replace(/{@atkr m,r}/g, `Melee or Ranged Attack Roll:`)
         .replace(/{@creature (.+?)(?:\|.+)?}/g, `$1`)
         .replace(/{@skill (.+?)(?:\|.+)?}/g, `$1`)
         .replace(/{@dice (.+?)(?:\|.+)?}/g, `$1`)
         .replace(/{@hit (\d+?)(?:\|.+)?}/g, `+$1`)
         .replace(/{@dc (\d+?)(?:\|.+)?}/g, `$1`)
-        .replace(/{@quickref (.+?)\|\|.+?}/, `$1`);
+        .replace(/{@quickref (.+?)\|\|.+?}/, `$1`)
+        .replace(/{@actSave str}/g, `Strength Saving Throw:`)
+        .replace(/{@actSave dex}/g, `Dexterity Saving Throw:`)
+        .replace(/{@actSave con}/g, `Constitution Saving Throw:`)
+        .replace(/{@actSave int}/g, `Inteligence Saving Throw:`)
+        .replace(/{@actSave wis}/g, `Wisdom Saving Throw:`)
+        .replace(/{@actSave cha}/g, `Charisma Saving Throw:`)
+        .replace(/{@actSaveFail}/g, `Failure:`)
+        .replace(/{@actSaveSuccess}/g, `Success:`)
+        .replace(/{actSaveSuccessOrFail}/g, `Failure or Success:`)
+        .replace(/{@variantrule (.+?)( |\|).+?}/g,`$1`)
+        ;
+
 }
 
 export async function build5eMonsterFromFile(file: File): Promise<Monster[]> {

--- a/src/importers/5eToolsImport.ts
+++ b/src/importers/5eToolsImport.ts
@@ -57,7 +57,7 @@ function parseString(str: string) {
         .replace(/{@actSaveFail}/g, `Failure:`)
         .replace(/{@actSaveSuccess}/g, `Success:`)
         .replace(/{actSaveSuccessOrFail}/g, `Failure or Success:`)
-        .replace(/{@variantrule (.+?)( |\|).+?}/g,`$1`)
+        .replace(/{@variantrule (.+?)( \[|\|).+?}/g,`$1`)
         ;
 
 }

--- a/src/importers/5eToolsImport.ts
+++ b/src/importers/5eToolsImport.ts
@@ -42,6 +42,7 @@ function parseString(str: string) {
         .replace(/{@atkr m}/g, `Melee Attack Roll:`)
         .replace(/{@atkr r}/g, `Ranged Attack Roll:`)
         .replace(/{@atkr m,r}/g, `Melee or Ranged Attack Roll:`)
+        .replace(/{@hom}/g, `Hit or Miss:`)
         .replace(/{@creature (.+?)(?:\|.+)?}/g, `$1`)
         .replace(/{@skill (.+?)(?:\|.+)?}/g, `$1`)
         .replace(/{@dice (.+?)(?:\|.+)?}/g, `$1`)
@@ -57,8 +58,7 @@ function parseString(str: string) {
         .replace(/{@actSaveFail}/g, `Failure:`)
         .replace(/{@actSaveSuccess}/g, `Success:`)
         .replace(/{actSaveSuccessOrFail}/g, `Failure or Success:`)
-        .replace(/{@variantrule (.+?)( \[|\|).+?}/g,`$1`)
-        ;
+        .replace(/{@variantrule (.+?)( \[|\|).+?}/g,`$1`);
 
 }
 


### PR DESCRIPTION
## Pull Request Description

Add additional parseString variables to the 5eToolsImport to account for updates to the 2025 Monster Manual.

## Changes Proposed

Update now supports:
- [x] new @actSave abc format
- [x] new @actSave[Fail, Success, SuccessOrFail] formats
- [x] new @variantrule Thing [Area of Effect]|source|Thing and @variantrule Thing|source formats.
- [x] new @atkr [m, r, "m,r"] formats

## Related Issues

<!-- Mention any related issues or tasks that are addressed by this pull request -->

Fixes #Issue_Number

## Checklist

<!-- Make sure to check the items below before submitting your pull request -->

- [x] I have read the contribution guidelines and code of conduct.
- [x] I have tested the changes locally and they are working as expected.
- [x] I have added appropriate comments and documentation for the code changes.
- [x] My code follows the coding style and standards of this project.
- [x] I have rebased my branch on the latest main (or master) branch.
- [x] All tests (if applicable) have passed successfully.
- [x] I have run linters and fixed any issues.
- [x] I have checked for any potential security issues or vulnerabilities.


## Additional Notes

To fully support 5eTools, more changes are needed including supporting multiple sizes and storing lair attributes but this is a start.

BEGIN_COMMIT_OVERRIDE
fix: Add support for additional variables with 5etools importer
END_COMMIT_OVERRIDE