### PR TITLE
Improvements to trait modification

### DIFF
--- a/src/view/statblock.ts
+++ b/src/view/statblock.ts
@@ -187,15 +187,6 @@ export default class StatBlockRenderer extends MarkdownRenderChild {
                          */
                         for (const creature of [...extensions]) {
                             /**
-                             * Deleted traits. These are always removed.
-                             */
-                            for (const trait of getTraitsList(
-                                `${property}-` as keyof Monster,
-                                creature
-                            )) {
-                                $TRAIT_MAP.delete(trait.name);
-                            }
-                            /**
                              * Directly defined traits.
                              *
                              * Because these can be overridden, they go into a map by name.
@@ -205,6 +196,16 @@ export default class StatBlockRenderer extends MarkdownRenderChild {
                                 creature
                             )) {
                                 $TRAIT_MAP.set(trait.name, trait);
+                            }
+
+                            /**
+                             * Deleted traits. These are always removed.
+                             */
+                            for (const trait of getTraitsList(
+                                `${property}-` as keyof Monster,
+                                creature
+                            )) {
+                                $TRAIT_MAP.delete(trait.name);
                             }
 
                             /**

--- a/src/view/statblock.ts
+++ b/src/view/statblock.ts
@@ -209,6 +209,20 @@ export default class StatBlockRenderer extends MarkdownRenderChild {
                             }
 
                             /**
+                             * Modifiable traits. These traits modify existing traits by name.
+                             * If the trait does not exist, it is ignored.
+                             */
+
+                            for (const trait of getTraitsList(
+                                `${property}~` as keyof Monster,
+                                creature
+                            )) {
+                                if ($TRAIT_MAP.has(trait.name)) {
+                                    $TRAIT_MAP.set(trait.name, trait);
+                                }
+                            }
+
+                            /**
                              * Additive traits. These traits are always shown.
                              */
                             for (const trait of getTraitsList(


### PR DESCRIPTION
## Pull Request Description

Improvements for the trait modification features.

## Changes Proposed

- [x] Fix trait removal by adding existing traits to map before attempting to delete
- [x] QOL change to modify traits in place, before needed to use both "actions-" and "actions+", now contained in one operation

## Related Issues

Fixes #515

## Checklist

- [x] I have read the contribution guidelines and code of conduct.
- [x] I have tested the changes locally and they are working as expected.
- [x] I have added appropriate comments and documentation for the code changes.
- [x] My code follows the coding style and standards of this project.
- [x] I have rebased my branch on the latest main (or master) branch.
- [x] All tests (if applicable) have passed successfully.
- [x] I have run linters and fixed any issues.
- [x] I have checked for any potential security issues or vulnerabilities.

## Screenshots (if applicable)

<img width="1038" height="914" alt="fantasy-statblocks-test" src="https://github.com/user-attachments/assets/821b6eb2-ebfd-425b-a569-71d751170ee0" />

BEGIN_COMMIT_OVERRIDE
fix: Improvements to trait modification
END_COMMIT_OVERRIDE
